### PR TITLE
Write ~/.ninny.yml file anyway, even if TTY doesn't work

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,5 +20,8 @@ Lint/EmptyBlock:
 Lint/MissingSuper:
   Enabled: false
 
+Metrics/MethodLength:
+  Max: 15
+
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/lib/ninny/commands/setup.rb
+++ b/lib/ninny/commands/setup.rb
@@ -22,7 +22,7 @@ module Ninny
           #   releases versions compatible with thor >= 2 as well as < 2
           config.write(force: true)
         rescue StandardError
-          puts '  Unable to update your ~/.ninny.yml file via TTY... continuing...'
+          puts '  Unable to write config file via TTY... continuing anyway...'
           File.open("#{ENV['HOME']}/.ninny.yml", 'w') do |file|
             file.puts "gitlab_private_token: #{private_token}"
           end
@@ -54,7 +54,7 @@ module Ninny
           #   releases versions compatible with thor >= 2 as well as < 2
           config.set(:gitlab_private_token, value: private_token)
         rescue ArgumentError
-          puts '  Unable to set new token via TTY... continuing...'
+          puts '  Unable to set new token via TTY... continuing anyway...'
         end
 
         private_token

--- a/lib/ninny/commands/setup.rb
+++ b/lib/ninny/commands/setup.rb
@@ -18,8 +18,8 @@ module Ninny
         private_token = prompt_for_gitlab_private_token
 
         begin
-          # TODO: This only works with thor gem < 2. So, we need to make this work when TTY
-          #   releases versions compatible with thor >= 2 as well as < 2
+          # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
+          #   releases versions compatible with thor versions >= 1 as well.
           config.write(force: true)
         rescue StandardError
           puts '  Unable to write config file via TTY... continuing anyway...'
@@ -50,8 +50,8 @@ module Ninny
         private_token = prompt.ask('Enter private token:', required: true)
 
         begin
-          # TODO: This only works with thor gem < 2. So, we need to make this work when TTY
-          #   releases versions compatible with thor >= 2 as well as < 2
+          # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
+          #   releases versions compatible with thor versions >= 1 as well.
           config.set(:gitlab_private_token, value: private_token)
         rescue ArgumentError
           puts '  Unable to set new token via TTY... continuing anyway...'

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end

--- a/spec/unit/setup_spec.rb
+++ b/spec/unit/setup_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ninny::Commands::Setup do
 
     subject.execute(output: output)
 
-    expect(output.string).to eq("User config \n")
+    expect(output.string).to eq("User config !\n")
   end
 
   context '#try_reading_user_config' do

--- a/spec/unit/setup_spec.rb
+++ b/spec/unit/setup_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe Ninny::Commands::Setup do
     context 'when unable to set via TTY' do
       it 'should move on anyway' do
         allow(Ninny.user_config).to receive(:gitlab_private_token)
-        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with('Do you have a GitLab private token?').and_return(true)
+        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with(
+          'Do you have a GitLab private token?'
+        ).and_return(true)
         allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
           'Enter private token:',
           required: true
@@ -76,7 +78,9 @@ RSpec.describe Ninny::Commands::Setup do
 
       it 'should return the private token' do
         allow(Ninny.user_config).to receive(:gitlab_private_token)
-        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with('Do you have a GitLab private token?').and_return(true)
+        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with(
+          'Do you have a GitLab private token?'
+        ).and_return(true)
         allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
           'Enter private token:',
           required: true

--- a/spec/unit/setup_spec.rb
+++ b/spec/unit/setup_spec.rb
@@ -10,10 +10,18 @@ RSpec.describe Ninny::Commands::Setup do
     expect(subject).to receive(:try_reading_user_config)
     expect(subject).to receive(:prompt_for_gitlab_private_token)
     output = StringIO.new
-
     subject.execute(output: output)
-
     expect(output.string).to eq("User config !\n")
+  end
+
+  context 'when unable to write the config file via TTY' do
+    it 'should move on and update it anyway' do
+      allow(subject).to receive(:try_reading_user_config)
+      allow(subject).to receive(:prompt_for_gitlab_private_token).and_return('yyy')
+      allow(Ninny.user_config).to receive(:write).with(force: true).and_raise(StandardError)
+      expect(File).to receive(:open).and_return(true)
+      subject.execute(output: StringIO.new)
+    end
   end
 
   context '#try_reading_user_config' do
@@ -52,6 +60,30 @@ RSpec.describe Ninny::Commands::Setup do
       ).and_return('yyy')
       expect(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy')
       subject.prompt_for_gitlab_private_token
+    end
+
+    context 'when unable to set via TTY' do
+      it 'should move on anyway' do
+        allow(Ninny.user_config).to receive(:gitlab_private_token)
+        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with('Do you have a GitLab private token?').and_return(true)
+        allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
+          'Enter private token:',
+          required: true
+        ).and_return('yyy')
+        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy').and_raise(ArgumentError)
+        subject.prompt_for_gitlab_private_token
+      end
+
+      it 'should return the private token' do
+        allow(Ninny.user_config).to receive(:gitlab_private_token)
+        allow_any_instance_of(TTY::Prompt).to receive(:yes?).with('Do you have a GitLab private token?').and_return(true)
+        allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
+          'Enter private token:',
+          required: true
+        ).and_return('yyy')
+        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy').and_raise(ArgumentError)
+        expect(subject.prompt_for_gitlab_private_token).to eq('yyy')
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

This gem requires `thor` version `< 2`. And, if the project that we run this gem in has that `thor` version, then the `ninny setup` command works perfectly. But what if the project has a greater `thor` version? Well, then this happens!

```bash
$ ninny setup
Do you have a new GitLab private token? Yes
Enter private token: PRIVATE-TOKEN-GOES-HERE
/Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/tty-config-0.4.0/lib/tty/config.rb:415:in `assert_either_value_or_block': Need to set either value or block (ArgumentError)
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/tty-config-0.4.0/lib/tty/config.rb:138:in `set'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/ninny-0.1.10.pre.test/lib/ninny/user_config.rb:20:in `set'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/ninny-0.1.10.pre.test/lib/ninny/commands/setup.rb:42:in `prompt_for_gitlab_private_token'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/ninny-0.1.10.pre.test/lib/ninny/commands/setup.rb:18:in `execute'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/ninny-0.1.10.pre.test/lib/ninny/cli.rb:62:in `setup'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
        from /Users/emmasax/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/ninny-0.1.10.pre.test/exe/ninny:15:in `<top (required)>'
        from /Users/emmasax/.rbenv/versions/3.0.0/bin/ninny:23:in `load'
        from /Users/emmasax/.rbenv/versions/3.0.0/bin/ninny:23:in `<main>'
```

The most realistic solution is to upgrade the `thor` and `tty` (which is what uses `thor`) gems so that they're `thor >= 1` compatible (aka it'd work with any `thor` version). But the versions of `tty` seem to be far out, and I'm not sure when they'll release new versions of `tty` and the `tty-*` gems that this uses.

So, I just took the blocks of `tty` that tended to fail (the one above being one, and the `config.write` being another), and put in rescue clauses. So I rescue if any of those break, and then write the `~/.ninny.yml` file the old-fashioned way... with good 'ol Ruby.

And then I also updated a couple of tests.

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

Make a new release of this gem, and then encourage engineers to upgrade if they desire!

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [x] Running `ninny setup` from a project with `thor > 2` succeeds
- [x] Running `ninny setup` from a project with `thor < 2` succeeds
- [x] Running all other ninny commands (`ninny help`) still works