### PR TITLE
Keep users in the loop when merging

### DIFF
--- a/lib/ninny/commands/pull_request_merge.rb
+++ b/lib/ninny/commands/pull_request_merge.rb
@@ -35,6 +35,7 @@ module Ninny
 
       # Public: Check out the branch
       def check_out_branch
+        prompt.say "Checking out #{branch_to_merge_into}."
         Ninny.git.check_out(branch_to_merge_into, false)
         Ninny.git.track_current_branch
       rescue Ninny::Git::NoBranchOfType
@@ -44,6 +45,7 @@ module Ninny
 
       # Public: Merge the pull request's branch into the checked-out branch
       def merge_pull_request
+        prompt.say "Merging #{pull_request.branch} to #{branch_to_merge_into}."
         Ninny.git.merge(pull_request.branch)
       end
 

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.11'
+  VERSION = '0.1.12'
 end

--- a/spec/unit/pull_request_merge_spec.rb
+++ b/spec/unit/pull_request_merge_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Ninny::Commands::PullRequestMerge do
 
   context '#merge_pull_request' do
     it 'should call merge between the branches' do
+      allow_any_instance_of(TTY::Prompt).to receive(:say).with("Merging pr_branch_name to staging-branch.")
+      allow(subject).to receive(:branch_to_merge_into).and_return('staging-branch')
       pr = double(:pull_request, branch: 'pr_branch_name')
       allow(subject).to receive(:pull_request).and_return(pr)
       expect(Ninny.git).to receive(:merge).with('pr_branch_name')

--- a/spec/unit/pull_request_merge_spec.rb
+++ b/spec/unit/pull_request_merge_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Ninny::Commands::PullRequestMerge do
 
   context '#merge_pull_request' do
     it 'should call merge between the branches' do
-      allow_any_instance_of(TTY::Prompt).to receive(:say).with("Merging pr_branch_name to staging-branch.")
+      allow_any_instance_of(TTY::Prompt).to receive(:say).with('Merging pr_branch_name to staging-branch.')
       allow(subject).to receive(:branch_to_merge_into).and_return('staging-branch')
       pr = double(:pull_request, branch: 'pr_branch_name')
       allow(subject).to receive(:pull_request).and_return(pr)


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

When we run `ninny stage_up`, sometimes it takes a second for the command to complete. I find that when this happens, I wonder what's really going on, and if the command is going to break. So, add in some `prompt.say` so that it keeps me updated of what's happening, and also tells me which branches it's working with.

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [x] `ninny stage_up` succeeds and outputs accordingly
