### PR TITLE
Fix issue with branch not tracking to remote on first run

### DIFF
--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -66,7 +66,7 @@ module Ninny
     # do_after_pull - Should a pull be done after checkout?
     def check_out(branch, do_after_pull = true)
       git.fetch
-      branch.checkout
+      git.checkout(branch)
       pull if do_after_pull
       raise CheckoutFailed, "Failed to check out '#{branch}'" unless current_branch.name == branch.name
     end


### PR DESCRIPTION

<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

This is all about preventing ninny staging merges that look like this

```
Merge branch 'staging.2021.02.28' of gitlab.com:dispatchllc/backend into staging.2021.02.28
```

When they should look like this

```
Merge remote-tracking branch 'origin/my-cool-feature-branch' into staging.2021.02.28
```

In other words... we want to merge the feature INTO staging, rather that starting staging on our feature branch and then merging staging into staging. In particular, it screws up the commit author on sentry deployments

### details 

When a user runs `ninny stage_up` for the first time on a new staging branch, it does not properly track the branch. The `branch.checkout` method in ruby-git actually does this

```sh
git branch 'my_branch'
git checkout 'my_branch'
```

(implementation here https://github.com/ruby-git/ruby-git/blob/e2fd4af0e8cf6721ebcb14bba8810a6eafa15ab4/lib/git/branch.rb)

and that first line causes the new branch to be setup on whatever branch the repo is currently on (not the remote branch). 

Later on, tracking is set up against the remote branch, and it does a `git pull` which merges the remote INTO the local.

Just running `git.checkout('my_branch')` seems to solve the problem, because it does not run the `git branch 'my_branch'` before the checkout.

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [x] Played around with ruby-git in irb.. verified that `git.checkout('branch_name')` has the behavior described above
