### PR TITLE
Add an option to pass the GitLab private token into the setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ Then, each developer on the project should set up a file at `~/.ninny.yml` on th
 
 ```bash
 $ ninny setup
-Do you have a new GitLab private token? (Y/n) y # enter 'y'
+Do you have a new GitLab private token? (Y/n) Yes # enter 'y'
 Enter private token: abc123def456ghi789jk # enter your private token
-User config updated
+User config updated!
+```
+
+Or, you can pass the private token in as part of the command:
+```bash
+$ ninny setup --token abc123def456ghi789jk # or '-t abc123def456ghi789jk' for short
+User config updated!
 ```
 
 The private token should be a personal access token for that person's GitLab account (generated [here](https://gitlab.com/-/profile/personal_access_tokens)).

--- a/lib/ninny/cli.rb
+++ b/lib/ninny/cli.rb
@@ -60,7 +60,7 @@ module Ninny
         invoke :help, ['setup']
       else
         require_relative 'commands/setup'
-        Ninny::Commands::Setup.new(options.merge(token: options[:token])).execute
+        Ninny::Commands::Setup.new(options).execute
       end
     end
   end

--- a/lib/ninny/cli.rb
+++ b/lib/ninny/cli.rb
@@ -54,12 +54,13 @@ module Ninny
 
     desc 'setup', 'Interactively setup configuration'
     method_option :help, aliases: '-h', type: :boolean, desc: 'Display usage information'
+    method_option :token, aliases: '-t', type: :string, desc: 'The GitLab token to add to the ~/.ninny.yml file'
     def setup(*)
       if options[:help]
         invoke :help, ['setup']
       else
         require_relative 'commands/setup'
-        Ninny::Commands::Setup.new(options).execute
+        Ninny::Commands::Setup.new(options.merge(token: options[:token])).execute
       end
     end
   end

--- a/lib/ninny/commands/setup.rb
+++ b/lib/ninny/commands/setup.rb
@@ -16,18 +16,17 @@ module Ninny
       def execute(output: $stdout)
         try_reading_user_config
 
-        unless private_token
-          private_token = prompt_for_gitlab_private_token
+        unless @private_token
+          @private_token = prompt_for_gitlab_private_token
 
-          unless private_token
+          unless @private_token
             output.puts "Please create a private token on GitLab and then rerun 'ninny setup'."
             return
           end
-
-          config_set_gitlab_private_token(private_token)
         end
 
-        write_gitlab_private_token(private_token)
+        set_response = config_set_gitlab_private_token(@private_token)
+        write_gitlab_private_token(@private_token, set_response)
         output.puts "User config #{@result}!"
       end
 
@@ -42,11 +41,15 @@ module Ninny
         # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
         #   releases versions compatible with thor versions >= 1 as well.
         config.set(:gitlab_private_token, value: private_token)
+        :success
       rescue ArgumentError
         puts '  Unable to set new token via TTY... continuing anyway...'
+        :failed
       end
 
-      def write_gitlab_private_token(private_token)
+      def write_gitlab_private_token(private_token, set_response)
+        raise StandardError unless set_response == :success
+
         # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
         #   releases versions compatible with thor versions >= 1 as well.
         config.write(force: true)

--- a/lib/ninny/commands/setup.rb
+++ b/lib/ninny/commands/setup.rb
@@ -24,7 +24,7 @@ module Ninny
             return
           end
 
-          set_gitlab_private_token(private_token)
+          config_set_gitlab_private_token(private_token)
         end
 
         write_gitlab_private_token(private_token)
@@ -38,7 +38,7 @@ module Ninny
         @result = 'created'
       end
 
-      def set_gitlab_private_token(private_token)
+      def config_set_gitlab_private_token(private_token)
         # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
         #   releases versions compatible with thor versions >= 1 as well.
         config.set(:gitlab_private_token, value: private_token)

--- a/lib/ninny/commands/setup.rb
+++ b/lib/ninny/commands/setup.rb
@@ -5,29 +5,29 @@ require_relative '../command'
 module Ninny
   module Commands
     class Setup < Ninny::Command
-      attr_reader :config
+      attr_reader :config, :private_token
 
       def initialize(options)
         @options = options
+        @private_token = options[:token]
         @config = Ninny.user_config
       end
 
       def execute(output: $stdout)
         try_reading_user_config
 
-        private_token = prompt_for_gitlab_private_token
+        unless private_token
+          private_token = prompt_for_gitlab_private_token
 
-        begin
-          # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
-          #   releases versions compatible with thor versions >= 1 as well.
-          config.write(force: true)
-        rescue StandardError
-          puts '  Unable to write config file via TTY... continuing anyway...'
-          File.open("#{ENV['HOME']}/.ninny.yml", 'w') do |file|
-            file.puts "gitlab_private_token: #{private_token}"
+          unless private_token
+            output.puts "Please create a private token on GitLab and then rerun 'ninny setup'."
+            return
           end
+
+          set_gitlab_private_token(private_token)
         end
 
+        write_gitlab_private_token(private_token)
         output.puts "User config #{@result}!"
       end
 
@@ -36,6 +36,23 @@ module Ninny
         @result = 'updated'
       rescue MissingUserConfig
         @result = 'created'
+      end
+
+      def set_gitlab_private_token(private_token)
+        # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
+        #   releases versions compatible with thor versions >= 1 as well.
+        config.set(:gitlab_private_token, value: private_token)
+      rescue ArgumentError
+        puts '  Unable to set new token via TTY... continuing anyway...'
+      end
+
+      def write_gitlab_private_token(private_token)
+        # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
+        #   releases versions compatible with thor versions >= 1 as well.
+        config.write(force: true)
+      rescue StandardError
+        puts '  Unable to write config file via TTY... continuing anyway...'
+        File.open("#{ENV['HOME']}/.ninny.yml", 'w') { |file| file.puts "gitlab_private_token: #{private_token}" }
       end
 
       def prompt_for_gitlab_private_token
@@ -47,17 +64,7 @@ module Ninny
 
         return unless prompt.yes?("Do you have a#{new_token_text} GitLab private token?")
 
-        private_token = prompt.ask('Enter private token:', required: true)
-
-        begin
-          # TODO: This only works with thor gem < 1. So, we need to make this work when TTY
-          #   releases versions compatible with thor versions >= 1 as well.
-          config.set(:gitlab_private_token, value: private_token)
-        rescue ArgumentError
-          puts '  Unable to set new token via TTY... continuing anyway...'
-        end
-
-        private_token
+        prompt.ask('Enter private token:', required: true)
       end
     end
   end

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.15'
+  VERSION = '0.1.14'
 end

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.13'
+  VERSION = '0.1.15'
 end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe '`ninny setup` command', type: :cli do
 
       Options:
         -h, [--help], [--no-help]  # Display usage information
+        -t, [--token=TOKEN]        # The GitLab token to add to the ~/.ninny.yml file
 
       Interactively setup configuration
     OUT

--- a/spec/unit/setup_spec.rb
+++ b/spec/unit/setup_spec.rb
@@ -6,9 +6,31 @@ require 'tty-prompt'
 # rubocop:disable Metrics/BlockLength
 RSpec.describe Ninny::Commands::Setup do
   subject { Ninny::Commands::Setup.new({}) }
+
   it 'executes `setup` command successfully' do
     expect(subject).to receive(:try_reading_user_config)
-    expect(subject).to receive(:prompt_for_gitlab_private_token)
+    expect(subject).to receive(:prompt_for_gitlab_private_token).and_return(:token)
+    expect(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: :token)
+    expect(subject).to receive(:write_gitlab_private_token).with(:token)
+    output = StringIO.new
+    subject.execute(output: output)
+    expect(output.string).to eq("User config !\n")
+  end
+
+  it 'returns when the user does not give a token' do
+    expect(subject).to receive(:try_reading_user_config)
+    expect(subject).to receive(:prompt_for_gitlab_private_token).and_return(nil)
+    output = StringIO.new
+    subject.execute(output: output)
+    expect(output.string).to eq("Please create a private token on GitLab and then rerun 'ninny setup'.\n")
+  end
+
+  it 'should not ask questions when the token is passed in' do
+    subject = Ninny::Commands::Setup.new({ token: :token })
+    expect(subject).to receive(:try_reading_user_config)
+    expect(subject).not_to receive(:prompt_for_gitlab_private_token)
+    expect(Ninny.user_config).not_to receive(:set)
+    expect(subject).to receive(:write_gitlab_private_token)
     output = StringIO.new
     subject.execute(output: output)
     expect(output.string).to eq("User config !\n")
@@ -17,7 +39,7 @@ RSpec.describe Ninny::Commands::Setup do
   context 'when unable to write the config file via TTY' do
     it 'should move on and update it anyway' do
       allow(subject).to receive(:try_reading_user_config)
-      allow(subject).to receive(:prompt_for_gitlab_private_token).and_return('yyy')
+      allow(subject).to receive(:prompt_for_gitlab_private_token).and_return(:token)
       allow(Ninny.user_config).to receive(:write).with(force: true).and_raise(StandardError)
       expect(File).to receive(:open).and_return(true)
       subject.execute(output: StringIO.new)
@@ -51,14 +73,13 @@ RSpec.describe Ninny::Commands::Setup do
       subject.prompt_for_gitlab_private_token
     end
 
-    it 'should ask for and set the new token' do
+    it 'should ask for the new token' do
       expect(Ninny.user_config).to receive(:gitlab_private_token)
       expect_any_instance_of(TTY::Prompt).to receive(:yes?).with('Do you have a GitLab private token?').and_return(true)
       expect_any_instance_of(TTY::Prompt).to receive(:ask).with(
         'Enter private token:',
         required: true
-      ).and_return('yyy')
-      expect(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy')
+      ).and_return(:token)
       subject.prompt_for_gitlab_private_token
     end
 
@@ -71,8 +92,8 @@ RSpec.describe Ninny::Commands::Setup do
         allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
           'Enter private token:',
           required: true
-        ).and_return('yyy')
-        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy').and_raise(ArgumentError)
+        ).and_return(:token)
+        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: :token).and_raise(ArgumentError)
         subject.prompt_for_gitlab_private_token
       end
 
@@ -84,9 +105,9 @@ RSpec.describe Ninny::Commands::Setup do
         allow_any_instance_of(TTY::Prompt).to receive(:ask).with(
           'Enter private token:',
           required: true
-        ).and_return('yyy')
-        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: 'yyy').and_raise(ArgumentError)
-        expect(subject.prompt_for_gitlab_private_token).to eq('yyy')
+        ).and_return(:token)
+        allow(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: :token).and_raise(ArgumentError)
+        expect(subject.prompt_for_gitlab_private_token).to eq(:token)
       end
     end
   end

--- a/spec/unit/setup_spec.rb
+++ b/spec/unit/setup_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Ninny::Commands::Setup do
     expect(subject).to receive(:try_reading_user_config)
     expect(subject).to receive(:prompt_for_gitlab_private_token).and_return(:token)
     expect(Ninny.user_config).to receive(:set).with(:gitlab_private_token, value: :token)
-    expect(subject).to receive(:write_gitlab_private_token).with(:token)
+    expect(subject).to receive(:write_gitlab_private_token).with(:token, :success)
     output = StringIO.new
     subject.execute(output: output)
     expect(output.string).to eq("User config !\n")
@@ -29,7 +29,7 @@ RSpec.describe Ninny::Commands::Setup do
     subject = Ninny::Commands::Setup.new({ token: :token })
     expect(subject).to receive(:try_reading_user_config)
     expect(subject).not_to receive(:prompt_for_gitlab_private_token)
-    expect(Ninny.user_config).not_to receive(:set)
+    expect(Ninny.user_config).to receive(:set)
     expect(subject).to receive(:write_gitlab_private_token)
     output = StringIO.new
     subject.execute(output: output)


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

Add an option for users to pass in their GitLab token automatically to the setup command. This is what currently exists:

```bash
$ ninny setup
Do you have a new GitLab private token? (Y/n) Yes # enter 'y'
Enter private token: abc123def456ghi789jk # enter your private token
User config updated!
```

Now, that'll still be an option, but users can also do this:
```bash
$ ninny setup --token abc123def456ghi789jk
User config updated!
```

This is going to be particularly helpful if we automate the `ninny setup` process even more.

Also, now if a user says `'n'` to the initial question, then the command will end, versus updating the ninny file to be empty:
```bash
$ ninny setup
Do you have a new GitLab private token? no # enter 'n'
Please create a private token on GitLab and then rerun 'ninny setup'.
```

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [ ] Running `ninny setup` works both with the token passed in and with it as part of the questions
