### PR TITLE
Write the name of the user that stages up

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ $ ninny staging_branch
 
 # To merge the current branch into the current/latest staging branch
 $ ninny stage_up
-
 ```
 
 At any point, `ninny help` will show the help screen.

--- a/lib/ninny/cli.rb
+++ b/lib/ninny/cli.rb
@@ -31,7 +31,8 @@ module Ninny
 
     desc 'stage_up [PULL_REQUEST_ID]', 'Merges PR/MR into the staging branch'
     method_option :help, aliases: '-h', type: :boolean, desc: 'Display usage information'
-    method_option :username, aliases: '-u', type: :string, desc: "The name of the user who is staging up; defaults to the local git config's user"
+    method_option :username, aliases: '-u', type: :string,
+                             desc: "The name of the user who is staging up; defaults to the local git config's user"
     def stage_up(pull_request_id = nil)
       if options[:help]
         invoke :help, ['stage_up']

--- a/lib/ninny/cli.rb
+++ b/lib/ninny/cli.rb
@@ -31,6 +31,7 @@ module Ninny
 
     desc 'stage_up [PULL_REQUEST_ID]', 'Merges PR/MR into the staging branch'
     method_option :help, aliases: '-h', type: :boolean, desc: 'Display usage information'
+    method_option :username, aliases: '-u', type: :string, desc: "The name of the user who is staging up; defaults to the local git config's user"
     def stage_up(pull_request_id = nil)
       if options[:help]
         invoke :help, ['stage_up']

--- a/lib/ninny/commands/pull_request_merge.rb
+++ b/lib/ninny/commands/pull_request_merge.rb
@@ -66,7 +66,7 @@ module Ninny
       # Returns a String
       def comment_body
         user = username || determine_local_user
-        body = "Merged into #{branch_to_merge_into}"
+        body = "Merged into #{branch_to_merge_into}".dup
         body << " by #{user}" if user
         body << '.'
       end

--- a/lib/ninny/commands/pull_request_merge.rb
+++ b/lib/ninny/commands/pull_request_merge.rb
@@ -6,7 +6,7 @@ module Ninny
   module Commands
     class PullRequestMerge < Ninny::Command
       attr_accessor :pull_request_id, :options, :pull_request
-      attr_reader :branch_type
+      attr_reader :branch_type, :username
 
       def initialize(pull_request_id, options)
         @branch_type = options[:branch_type] || Ninny::Git::STAGING_PREFIX
@@ -65,7 +65,10 @@ module Ninny
       #
       # Returns a String
       def comment_body
-        "Merged into #{branch_to_merge_into}."
+        user = username || determine_local_user
+        body = "Merged into #{branch_to_merge_into}"
+        body << " by #{user}" if user
+        body << '.'
       end
 
       # Public: Find the pull request
@@ -82,6 +85,11 @@ module Ninny
       # Returns a String
       def branch_to_merge_into
         @branch_to_merge_into ||= Ninny.git.latest_branch_for(branch_type)
+      end
+
+      def determine_local_user
+        local_user_name = `git config user.name`.strip
+        local_user_name.empty? ? nil : local_user_name
       end
     end
   end

--- a/lib/ninny/commands/stage_up.rb
+++ b/lib/ninny/commands/stage_up.rb
@@ -9,6 +9,7 @@ module Ninny
       def initialize(pull_request_id, options)
         super
         @branch_type = Ninny::Git::STAGING_PREFIX
+        @username = options[:username]
       end
     end
   end

--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -95,7 +95,7 @@ module Ninny
     rescue ::Git::GitExecuteError => e
       if e.message.include?(':fatal: A branch named') && e.message.include?(' already exists')
         puts "The local branch #{new_branch_name} already exists." \
-          ' Please delete it manually and then run this command again.'
+             ' Please delete it manually and then run this command again.'
         exit 1
       end
     end

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.17'
+  VERSION = '0.1.18'
 end

--- a/spec/integration/stage_up_spec.rb
+++ b/spec/integration/stage_up_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe '`ninny stage_up` command', type: :cli do
 
       Options:
         -h, [--help], [--no-help]  # Display usage information
+        -u, [--username=USERNAME]  # The name of the user who is staging up; defaults to the local git config's user
 
       Merges PR/MR into the staging branch
     OUT


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

With this change, Ninny will print the name of the user who stages up in the pull request comment body:
```
Merged into staging.2021.08.06 by Emma Sax.
```

It will run `git config user.name` to grab the name. If there is no username set in the local machine's git config, then it'll skip the ending and return the plain message:

```
Merged into staging.2021.08.06.
```

However, now we can override the user's name as well:

```
$ ninny stage_up --username='Other User Name'
```

This outputs:

```
Merged into staging.2021.08.06 by Other User Name.
```

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

```
gem build *.gemspec
gem install --local ninny-....gem
```

- [x] Test that running `ninny stage_up` without a username given comments that your local user name merged
- [x] Test that running `ninny stage-up --username=Other` comments that somebody named `Other` merged
- [x] Remove your local user name from your `~/.gitconfig` file and run `ninny stage_up` and note how it completely leaves off the user's name because none was found