### PR TITLE
Show more than 20 open MRs at a time

### DIFF
--- a/lib/ninny/repository/gitlab.rb
+++ b/lib/ninny/repository/gitlab.rb
@@ -15,14 +15,14 @@ module Ninny
 
       def current_pull_request
         to_pr(
-          all_merge_requests(
+          gitlab.merge_requests(
             project_id,
             {
               source_branch: Ninny.git.current_branch.name,
               target_branch: Ninny.project_config.deploy_branch,
               state: 'opened'
             }
-          ).last
+          ).auto_paginate.last
         )
       end
 
@@ -31,7 +31,7 @@ module Ninny
       end
 
       def open_pull_requests
-        all_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
+        gitlab.merge_requests(project_id, { state: 'opened' }).auto_paginate.map { |mr| to_pr(mr) }
       end
 
       def pull_request(id)
@@ -52,22 +52,6 @@ module Ninny
         )
       end
       private :to_pr
-
-      def all_merge_requests(project_id, params)
-        page_number = 1
-        counter = 1
-        merge_requests = []
-
-        while counter.positive?
-          page_merge_requests = gitlab.merge_requests(project_id, params.merge(page: page_number, per_page: 100))
-          merge_requests.concat(page_merge_requests)
-          counter = page_merge_requests.count
-          page_number += 1
-        end
-
-        merge_requests
-      end
-      private :all_merge_requests
     end
   end
 end

--- a/lib/ninny/repository/gitlab.rb
+++ b/lib/ninny/repository/gitlab.rb
@@ -56,16 +56,16 @@ module Ninny
       def paginated_merge_requests(project_id, params)
         page_number = 1
         counter = 1
-        pull_requests = []
+        merge_requests = []
 
         while counter > 0
-          page_pull_requests = gitlab.merge_requests(project_id, params.merge(page: page_number, per_page: 100))
-          pull_requests.concat(page_pull_requests)
-          counter = page_pull_requests.count
+          page_merge_requests = gitlab.merge_requests(project_id, params.merge(page: page_number, per_page: 100))
+          merge_requests.concat(page_merge_requests)
+          counter = page_merge_requests.count
           page_number += 1
         end
 
-        pull_requests
+        merge_requests
       end
     end
   end

--- a/lib/ninny/repository/gitlab.rb
+++ b/lib/ninny/repository/gitlab.rb
@@ -15,7 +15,7 @@ module Ninny
 
       def current_pull_request
         to_pr(
-          gitlab.merge_requests(
+          gitlab.paginated_merge_requests(
             project_id,
             {
               source_branch: Ninny.git.current_branch.name,
@@ -31,7 +31,7 @@ module Ninny
       end
 
       def open_pull_requests
-        gitlab.merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
+        gitlab.paginated_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
       end
 
       def pull_request(id)
@@ -52,6 +52,21 @@ module Ninny
         )
       end
       private :to_pr
+
+      def paginated_merge_requests(project_id, params)
+        page_number = 1
+        counter = 1
+        pull_requests = []
+
+        while counter > 0
+          page_pull_requests = gitlab.merge_requests(project_id, params.merge(page: page_number, per_page: 100))
+          pull_requests.concat(page_pull_requests)
+          counter = page_pull_requests.count
+          page_number += 1
+        end
+
+        pull_requests
+      end
     end
   end
 end

--- a/lib/ninny/repository/gitlab.rb
+++ b/lib/ninny/repository/gitlab.rb
@@ -15,7 +15,7 @@ module Ninny
 
       def current_pull_request
         to_pr(
-          paginated_merge_requests(
+          all_merge_requests(
             project_id,
             {
               source_branch: Ninny.git.current_branch.name,
@@ -31,7 +31,7 @@ module Ninny
       end
 
       def open_pull_requests
-        paginated_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
+        all_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
       end
 
       def pull_request(id)
@@ -53,12 +53,12 @@ module Ninny
       end
       private :to_pr
 
-      def paginated_merge_requests(project_id, params)
+      def all_merge_requests(project_id, params)
         page_number = 1
         counter = 1
         merge_requests = []
 
-        while counter > 0
+        while counter.positive?
           page_merge_requests = gitlab.merge_requests(project_id, params.merge(page: page_number, per_page: 100))
           merge_requests.concat(page_merge_requests)
           counter = page_merge_requests.count
@@ -67,7 +67,7 @@ module Ninny
 
         merge_requests
       end
-      private :paginated_merge_requests
+      private :all_merge_requests
     end
   end
 end

--- a/lib/ninny/repository/gitlab.rb
+++ b/lib/ninny/repository/gitlab.rb
@@ -15,7 +15,7 @@ module Ninny
 
       def current_pull_request
         to_pr(
-          gitlab.paginated_merge_requests(
+          paginated_merge_requests(
             project_id,
             {
               source_branch: Ninny.git.current_branch.name,
@@ -31,7 +31,7 @@ module Ninny
       end
 
       def open_pull_requests
-        gitlab.paginated_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
+        paginated_merge_requests(project_id, { state: 'opened' }).map { |mr| to_pr(mr) }
       end
 
       def pull_request(id)
@@ -67,6 +67,7 @@ module Ninny
 
         merge_requests
       end
+      private :paginated_merge_requests
     end
   end
 end

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.18'
+  VERSION = '0.1.19'
 end


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

When listing all of the open merge requests, Ninny only shows the most recent 20 MRs. This is because the GitLab API by default paginates the merge requests, and therefore is only showing the first page of MRs (which is 20). But because we want to show ALL open MRs, we should loop through all of the MR pages and concat the whole list together.

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [x] Running `ninny stage_up` now shows all MRs, which (in our case) should be more than 20
